### PR TITLE
feat(specs): add sudo-auth spec for macOS Touch ID optimization

### DIFF
--- a/.kiro/specs/sudo-auth/brief.md
+++ b/.kiro/specs/sudo-auth/brief.md
@@ -1,0 +1,53 @@
+# Brief: sudo-auth
+
+## Problem
+Users running htotheizzo.sh on macOS with Touch ID for sudo get prompted 3+ times for fingerprint/password during a single run. The `keep_sudo_alive()` function calls `sudo -v` every 50 seconds, but macOS's sudo timestamp is 5 minutes — each `sudo -v` call triggers a Touch ID PAM sheet even when credentials are still valid. Additionally, `sudo softwareupdate --install --all` silently downloads major OS upgrades (e.g. macOS Tahoe) and then prompts for an interactive password that bypasses sudo credential caching — surprising the user with no prior warning.
+
+## Current State
+
+- `keep_sudo_alive()` sleeps 50s between `sudo -v` calls — fires ~6× per 5-min sudo timeout window
+- Each `sudo -v` on macOS with `pam_tid` shows a Touch ID sheet even when credentials are valid
+- `sudo softwareupdate --install --all` runs without inspecting whether updates include a major OS upgrade
+- `skip_softwareupdate_major=1` exists as an escape hatch but is undiscoverable (no runtime warning)
+- GitHub issue: yanicklandry/htotheizzo#14
+
+## Desired Outcome
+
+- Touch ID prompts at most once at script start, plus once if credentials genuinely expire (>5 min) mid-run
+- Before installing a major OS upgrade, print a clear warning that an interactive password will be required, and remind the user they can set `skip_softwareupdate_major=1` to skip it
+- No behavioral change for non-macOS platforms or when `pam_tid` is not in use
+
+## Approach
+
+Two targeted fixes in `htotheizzo.sh`:
+
+1. **Keepalive interval**: Change `sleep 50` to `sleep 240` in `keep_sudo_alive()`. Credentials expire after 300s; sleeping 240s refreshes them with ~60s margin, keeping exactly one Touch ID prompt per 5-min window at most.
+
+2. **Major upgrade warning**: After capturing `sw_list`, inspect it for lines that indicate a major OS upgrade (version number differs from current `sw_vers -productVersion` major). If found, print a prominent warning with `log` before running `--install --all`, telling the user an interactive password will be required and how to opt out.
+
+## Scope
+- **In**: `htotheizzo.sh` — `keep_sudo_alive()` function, `softwareupdate` block
+- **Out**: changing the sudo PAM configuration, removing `keep_sudo_alive` entirely, fixing Linux/Windows paths, modifying the initial `sudo -v` auth gate
+
+## Boundary Candidates
+- Keepalive timing fix (pure interval change, no logic change)
+- Major upgrade detection and warning (sw_list parsing + log output)
+
+## Out of Boundary
+- This spec does not change how many `sudo` calls other parts of the script make
+- This spec does not suppress the macOS password prompt for major upgrades (Apple enforces it)
+- This spec does not add skip flags for individual sudo operations
+
+## Upstream / Downstream
+- **Upstream**: `keep_sudo_alive()` at line 72; softwareupdate block at line 993
+- **Downstream**: none — this is a standalone UX fix
+
+## Existing Spec Touchpoints
+- **Extends**: none
+- **Adjacent**: script-cleanup touched the sudo area (removed two stray `sudo -v` calls)
+
+## Constraints
+- Must not break Linux path (keepalive is used there too; 240s interval is safe on any platform)
+- Must not remove the initial `sudo -v` auth gate
+- Major upgrade detection must be resilient to `softwareupdate --list` output format changes (use a loose heuristic, not a rigid parser)
+- Must pass `./test.sh`

--- a/.kiro/specs/sudo-auth/design.md
+++ b/.kiro/specs/sudo-auth/design.md
@@ -1,0 +1,196 @@
+# Design Document: sudo-auth
+
+## Overview
+
+This feature delivers two targeted fixes to `htotheizzo.sh` that reduce unnecessary Touch ID prompts and add a clear warning before a major macOS OS upgrade is installed.
+
+**Purpose**: Improve the operator experience on macOS by aligning credential refresh timing with the sudo credential window and surfacing an actionable warning when `softwareupdate` would install a major OS upgrade.
+
+**Users**: macOS users running `htotheizzo.sh` interactively with Touch ID-enabled sudo (`pam_tid`).
+
+**Impact**: Changes one constant in `keep_sudo_alive()` and adds a detection-and-warning block in the `softwareupdate` section. No behavior change on Linux or when `skip_softwareupdate_major=1` is set.
+
+### Goals
+- Reduce Touch ID prompts to at most one per 5-minute sudo credential window
+- Warn the user before a major OS upgrade installation requires an interactive password
+- Preserve all existing behavior on non-macOS platforms and for non-major updates
+
+### Non-Goals
+- Modifying PAM configuration or the sudo credential timeout
+- Suppressing the macOS interactive password requirement for major upgrades
+- Changing the initial `sudo -v` auth gate or any other sudo call in the script
+- Adding new skip flags beyond the existing `skip_softwareupdate_major`
+
+## Boundary Commitments
+
+### This Spec Owns
+- The `sleep` interval inside `keep_sudo_alive()` (lines 72–77 of `htotheizzo.sh`)
+- The major-upgrade detection heuristic and warning log immediately before the `softwareupdate --install --all` call (lines 993–1010 of `htotheizzo.sh`)
+
+### Out of Boundary
+- PAM configuration, `sudoers` TTL changes, or launchd credential-extension techniques
+- Other `sudo` calls throughout the script
+- The initial `sudo -v` prompt at script start
+- Linux/Windows update paths (interval change is safe; no platform-specific logic added)
+
+### Allowed Dependencies
+- `sw_vers -productVersion` — reads current macOS version (standard macOS CLI, always present)
+- `softwareupdate --list` output already captured in `sw_list` — no additional subprocess added
+- Existing `log` and `progress` shell functions in `htotheizzo.sh`
+
+### Revalidation Triggers
+- If Apple changes the `softwareupdate --list` output schema (e.g., removes "Version:" field) — update detection heuristic
+- If macOS sudo credential TTL changes from 5 minutes — recalculate `sleep` interval
+- If `keep_sudo_alive()` is refactored (e.g., moved to a shared lib) — verify interval constant travels with it
+
+## Architecture
+
+### Existing Architecture Analysis
+
+`htotheizzo.sh` is a single monolithic Bash script with no modules or imports. All logic lives in shell functions. The two affected areas are isolated:
+
+1. **`keep_sudo_alive()`** (lines 72–77): spawns a background loop that calls `sudo -v` then sleeps. The only change is the sleep constant.
+
+2. **softwareupdate block** (lines 993–1010): captures `sw_list` via `softwareupdate --list`, logs it, then branches on `skip_softwareupdate_major`. The addition inserts a detection step between the list capture and the install call.
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+flowchart TD
+    A[script start] --> B[sudo -v initial auth]
+    B --> C[keep_sudo_alive spawned]
+    C --> D[sleep 240s loop]
+    D -->|240s elapsed| E[sudo -v refresh]
+    E --> D
+
+    F[softwareupdate block] --> G[softwareupdate --list captured in sw_list]
+    G --> H{skip_softwareupdate_major set?}
+    H -->|yes| I[install --recommended only, no warning]
+    H -->|no| J{major upgrade in sw_list?}
+    J -->|yes| K[log prominent warning]
+    K --> L[sudo softwareupdate --install --all]
+    J -->|no| L
+```
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature |
+|-------|-----------------|-----------------|
+| Shell script | Bash (existing) | Only file changed; no new dependencies |
+| macOS CLI | `sw_vers` (built-in) | Read current major version for detection heuristic |
+| macOS CLI | `softwareupdate --list` (existing call) | Already captured; output reused for major-upgrade detection |
+
+## File Structure Plan
+
+### Modified Files
+- `htotheizzo.sh` — Two localized changes:
+  1. `keep_sudo_alive()` function: change `sleep 50` → `sleep 240`
+  2. `softwareupdate` block: insert major-upgrade detection and warning between list capture and install call
+
+No new files are created by this feature.
+
+## System Flows
+
+The flowchart in Architecture covers the branching logic. No additional diagrams needed.
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Notes |
+|-------------|---------|------------|-------|
+| 1.1 | Refresh no more than once per 240s | `keep_sudo_alive()` interval | `sleep 50` → `sleep 240` |
+| 1.2 | At most one Touch ID prompt per 5-min window | `keep_sudo_alive()` interval | Satisfied by 1.1; 240s < 300s timeout |
+| 1.3 | Non-macOS equivalence | `keep_sudo_alive()` interval | 240s is safe on Linux; loop logic unchanged |
+| 2.1 | Warn when major upgrade detected | `MajorUpgradeGuard` | Detection heuristic compares version majors |
+| 2.2 | Warning states interactive password required | `MajorUpgradeGuard` | Warning message content |
+| 2.3 | Warning mentions `skip_softwareupdate_major=1` | `MajorUpgradeGuard` | Warning message content |
+| 2.4 | No warning when no major upgrade present | `MajorUpgradeGuard` | Guard exits silently if no major found |
+| 2.5 | Resilient detection heuristic | `MajorUpgradeGuard` | Pattern matches "Version: N"; not hardcoded names |
+| 2.6 | No warning when `skip_softwareupdate_major=1` | `MajorUpgradeGuard` | Guard only runs when flag is unset |
+
+## Components and Interfaces
+
+| Component | Layer | Intent | Req Coverage | Key Dependencies |
+|-----------|-------|--------|--------------|-----------------|
+| KeepAliveInterval | Shell function | Sleep constant determining credential refresh cadence | 1.1, 1.2, 1.3 | None |
+| MajorUpgradeGuard | Shell inline block | Detect major OS upgrades in sw_list and emit warning | 2.1–2.6 | `sw_vers`, existing `sw_list` var, `log` function |
+
+### Shell Layer
+
+#### KeepAliveInterval
+
+| Field | Detail |
+|-------|--------|
+| Intent | Control how frequently `keep_sudo_alive()` calls `sudo -v` |
+| Requirements | 1.1, 1.2, 1.3 |
+
+**Responsibilities & Constraints**
+- Change the sleep constant from 50 to 240 seconds
+- The loop structure and all other behavior of `keep_sudo_alive()` remain unchanged
+- 240s is unconditionally safe on all platforms (shorter than sudo TTL on Linux too)
+
+**Contracts**: none (internal constant change)
+
+**Implementation Notes**
+- Single-line change: `sleep 50` → `sleep 240` in `keep_sudo_alive()`
+- Risk: none — arithmetic is the only concern; 240 < 300 (macOS sudo TTL) confirmed
+
+---
+
+#### MajorUpgradeGuard
+
+| Field | Detail |
+|-------|--------|
+| Intent | Detect major OS upgrade in `sw_list` output and log a prominent warning before installation |
+| Requirements | 2.1, 2.2, 2.3, 2.4, 2.5, 2.6 |
+
+**Responsibilities & Constraints**
+- Runs only when `skip_softwareupdate_major` is unset (requirement 2.6: guard is bypassed when the flag is set, since no major upgrade will be installed)
+- Reads `sw_vers -productVersion` to extract the current major version integer
+- Parses `sw_list` for `Version: N` patterns; compares each `N` to current major
+- If any update has a different (higher) major: calls `log` with a multi-line prominent warning
+- Does not modify `sw_list`, does not launch any new subprocess beyond `sw_vers`
+
+**Detection Heuristic** (resilient, not a rigid parser):
+```
+current_major = sw_vers -productVersion | cut -d. -f1    # e.g. "15"
+for each "Version: X.Y" in sw_list:
+    if X != current_major → major upgrade detected
+```
+Pattern match on integer-prefixed version numbers avoids dependence on macOS release name strings (requirement 2.5).
+
+**Warning Message Contract** (must include, in order):
+1. A `⚠` or `WARNING` indicator visible in the `log` output
+2. Statement that a major OS upgrade is available (include version if detectable)
+3. Statement that installation will require an interactive password (bypasses sudo credential cache)
+4. Reminder: set `skip_softwareupdate_major=1` to skip major upgrades
+
+**Dependencies**
+- Inbound: `sw_list` (already populated in softwareupdate block) — `P0`
+- Outbound: `log` function — `P0`
+- External: `sw_vers -productVersion` — `P0` (standard macOS binary, always present)
+
+**Contracts**: none (no exported interface; inline shell block)
+
+**Implementation Notes**
+- Integration: insert detection block between `sw_list` capture and the `if [[ -z "${skip_softwareupdate_major:-}" ]]` branch — inside the outer `if [[ -z "${skip_softwareupdate}" ]]` guard
+- Validation: manually test with mocked `sw_list` containing "Version: 26" while on macOS 15
+- Risk: `sw_vers` absence — not possible on macOS; no guard needed
+- Risk: heuristic false positive (e.g., minor update misread as major) — mitigated by extracting only the integer before the first `.` in the version field
+
+## Error Handling
+
+### Error Strategy
+Both changes follow the existing script pattern: failures are logged as warnings and do not halt the script.
+
+- If `sw_vers -productVersion` returns unexpected output: detection heuristic falls back to no-warning (safe default — does not block installation)
+- If `softwareupdate --install --all` fails: existing `|| log "Warning: ..."` handler covers it (unchanged)
+- Keepalive `sudo -v` failures: already handled by `2>/dev/null` in the existing loop
+
+## Testing Strategy
+
+### Manual / Smoke Tests
+1. **Keepalive interval**: Confirm `keep_sudo_alive()` contains `sleep 240` (grep check); run script and observe that only one Touch ID prompt fires in the first 5 minutes
+2. **Major upgrade detected**: Mock `sw_list` with a "Version: 26" line while on macOS 15; verify warning is printed containing "interactive password" and "skip_softwareupdate_major=1"
+3. **No major upgrade**: Mock `sw_list` with only "Version: 15" lines; verify no warning is printed
+4. **skip_softwareupdate_major=1 set**: Set flag and mock a major-upgrade `sw_list`; verify no warning is printed and `--recommended` is used
+5. **Non-macOS path**: On Linux, confirm keepalive loop runs without error (240s interval accepted)

--- a/.kiro/specs/sudo-auth/requirements.md
+++ b/.kiro/specs/sudo-auth/requirements.md
@@ -1,0 +1,37 @@
+# Requirements Document
+
+## Introduction
+htotheizzo.sh has two sudo/auth UX issues on macOS that cause unnecessary friction:
+
+1. **Excessive Touch ID prompts**: `keep_sudo_alive()` refreshes sudo credentials every 50 seconds, far more frequently than the 5-minute sudo credential timeout, triggering redundant Touch ID prompts during a single run.
+2. **Silent major OS upgrade**: `sudo softwareupdate --install --all` can silently install a major OS upgrade that requires an interactive password, surprising the user mid-run with no prior warning.
+
+This feature delivers two focused fixes in `htotheizzo.sh` to reduce unnecessary prompts and surface the major-upgrade warning at the right time.
+
+## Boundary Context
+- **In scope**: `keep_sudo_alive()` refresh interval; `softwareupdate` major-upgrade detection and warning in `htotheizzo.sh`
+- **Out of scope**: PAM or sudo configuration changes, suppression of the macOS interactive upgrade password, changes to other sudo calls in the script, Linux/Windows-specific code paths
+- **Adjacent expectations**: The initial `sudo -v` auth gate (invoked before `keep_sudo_alive()` is spawned) runs unchanged; this feature does not modify or remove it
+
+## Requirements
+
+### Requirement 1: Reduced Keepalive Refresh Interval
+
+**Objective:** As a macOS user running htotheizzo.sh, I want sudo credentials refreshed at an interval aligned with the 5-minute credential window, so that Touch ID is prompted at most once per credential window.
+
+#### Acceptance Criteria
+1. While `keep_sudo_alive()` is running, htotheizzo.sh shall refresh sudo credentials no more than once every 240 seconds, providing a ~60-second margin before the 5-minute sudo timeout expires.
+2. The htotheizzo.sh shall not prompt the user for sudo authentication more than once per 5-minute credential window during a normal script run.
+3. When running on Linux or other non-macOS platforms, htotheizzo.sh shall maintain equivalent keepalive behavior with no functional regression.
+
+### Requirement 2: Major OS Upgrade Detection and Warning
+
+**Objective:** As a macOS user, I want to be clearly warned before htotheizzo.sh installs a major OS upgrade, so that I am not surprised by an unexpected interactive password prompt mid-run.
+
+#### Acceptance Criteria
+1. When `softwareupdate --list` output contains an available update whose major version number differs from the current macOS major version, htotheizzo.sh shall print a prominent warning before attempting installation.
+2. When a major OS upgrade is detected, the warning shall state that installation will require an interactive password that bypasses sudo credential caching.
+3. When a major OS upgrade is detected, the warning shall inform the user that setting `skip_softwareupdate_major=1` will skip major OS upgrades and install only recommended updates instead.
+4. If `softwareupdate --list` output contains no major OS upgrades, htotheizzo.sh shall proceed to installation without printing a major-upgrade warning.
+5. The major upgrade detection shall use a resilient heuristic so that minor changes in `softwareupdate --list` formatting do not break detection.
+6. Where `skip_softwareupdate_major=1` is set, htotheizzo.sh shall not print the major-upgrade warning (since major upgrades will not be installed).

--- a/.kiro/specs/sudo-auth/research.md
+++ b/.kiro/specs/sudo-auth/research.md
@@ -1,0 +1,44 @@
+# Research Log: sudo-auth
+
+## Discovery Scope
+Minimal / Extension — two targeted edits to `htotheizzo.sh`. No external research required.
+
+## Codebase Analysis
+
+### keep_sudo_alive() (lines 72–77)
+```bash
+keep_sudo_alive() {
+  ( while kill -0 $$ 2>/dev/null; do sudo -v 2>/dev/null; sleep 50; done ) &
+  local keepalive_pid=$!
+  disown "$keepalive_pid" 2>/dev/null || true
+  trap "kill $keepalive_pid 2>/dev/null || true" EXIT INT TERM
+}
+```
+- Current interval: 50 seconds
+- macOS sudo TTL: ~300 seconds (5 minutes)
+- Problem: 50s fires 6× per TTL window; each `sudo -v` with `pam_tid` triggers Touch ID sheet
+- Fix: 240s → one refresh per window, ~60s safety margin
+
+### softwareupdate block (lines 993–1010)
+- `sw_list` captured via `softwareupdate --list 2>&1 | grep -v "^Software Update Tool" | grep -v "^Copyright"`
+- No major-upgrade detection exists
+- `skip_softwareupdate_major` already present as opt-out flag
+- Comment at line 1000–1002 acknowledges the interactive password requirement
+
+## Synthesis Outcomes
+
+### Build vs Adopt
+- No external libraries or tools. Detection logic is pure Bash using `sw_vers` (standard macOS CLI).
+
+### Heuristic Design Decision
+- Rejected: Matching on macOS release names (Sequoia, Tahoe, etc.) — brittle, breaks on new names
+- Adopted: Integer major version comparison via `sw_vers -productVersion | cut -d. -f1` vs `Version: N` in sw_list output
+- Rationale: Version integers are stable across Apple release naming conventions
+
+### Simplifications Applied
+- No new functions created — MajorUpgradeGuard is an inline shell block within the existing softwareupdate section
+- No new skip flags added — existing `skip_softwareupdate_major` already handles the opt-out case
+
+## Risks
+- Apple changes `softwareupdate --list` output format: mitigated by fallback-to-no-warning behavior if "Version:" not found
+- macOS sudo TTL changes: 240s is conservative; would need to revisit if TTL is reduced below 280s

--- a/.kiro/specs/sudo-auth/spec.json
+++ b/.kiro/specs/sudo-auth/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "sudo-auth",
+  "created_at": "2026-05-18T00:00:00Z",
+  "updated_at": "2026-05-18T00:00:00Z",
+  "language": "en",
+  "phase": "brief",
+  "approvals": {
+    "requirements": {
+      "generated": false,
+      "approved": false
+    },
+    "design": {
+      "generated": false,
+      "approved": false
+    },
+    "tasks": {
+      "generated": false,
+      "approved": false
+    }
+  },
+  "ready_for_implementation": false
+}

--- a/.kiro/specs/sudo-auth/spec.json
+++ b/.kiro/specs/sudo-auth/spec.json
@@ -1,21 +1,21 @@
 {
   "feature_name": "sudo-auth",
   "created_at": "2026-05-18T00:00:00Z",
-  "updated_at": "2026-05-18T00:00:00Z",
+  "updated_at": "2026-05-23T13:09:08Z",
   "language": "en",
-  "phase": "brief",
+  "phase": "implemented",
   "approvals": {
     "requirements": {
-      "generated": false,
-      "approved": false
+      "generated": true,
+      "approved": true
     },
     "design": {
-      "generated": false,
-      "approved": false
+      "generated": true,
+      "approved": true
     },
     "tasks": {
-      "generated": false,
-      "approved": false
+      "generated": true,
+      "approved": true
     }
   },
   "ready_for_implementation": false

--- a/.kiro/specs/sudo-auth/tasks.md
+++ b/.kiro/specs/sudo-auth/tasks.md
@@ -1,0 +1,27 @@
+# Implementation Plan
+
+- [x] 1. Fix keepalive refresh interval
+  - Locate `keep_sudo_alive()` in `htotheizzo.sh` (around line 73)
+  - Change `sleep 50` to `sleep 240` — this is a single-constant change; no other lines in the function are touched
+  - Run `bash -n htotheizzo.sh` to confirm no syntax errors were introduced
+  - `keep_sudo_alive()` contains `sleep 240`; all surrounding function logic is unchanged
+  - _Requirements: 1.1, 1.2, 1.3_
+
+- [x] 2. Add major OS upgrade detection and warning
+  - After `sw_list` is captured in the `softwareupdate` block (after the existing `while IFS= read -r line` log loop, before the `if [[ -z "${skip_softwareupdate_major:-}" ]]` branch), insert a detection block
+  - Read the current macOS major version: `sw_vers -productVersion | cut -d. -f1` (e.g. "15")
+  - Scan `sw_list` for lines matching `Version: N` (where N is an integer); extract the major integer from each matched line
+  - If any extracted major integer differs from the current major, call `log` with a prominent multi-line warning that includes: (a) a `WARNING` or `⚠` indicator, (b) a statement that a major macOS upgrade is available and will require an interactive password that bypasses sudo credential caching, (c) a reminder that setting `skip_softwareupdate_major=1` will skip major upgrades and use `--recommended` instead
+  - Place the detection block inside the outer `if [[ -z "${skip_softwareupdate:-}" ]]` guard; only run detection when `skip_softwareupdate_major` is unset (requirement 2.6: no warning when the flag suppresses the install anyway)
+  - If `sw_vers` returns unexpected output or no "Version:" line is found in `sw_list`, fall back silently (no warning, no error) — safe default
+  - Run `bash -n htotheizzo.sh` to confirm no syntax errors
+  - When `sw_list` contains an update with a different major version, the warning is printed to the log before installation; when no major upgrade is present, or when `skip_softwareupdate_major=1` is set, no warning appears
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6_
+
+- [x] 3. Smoke test both changes
+  - Verify `keep_sudo_alive()` contains `sleep 240` via grep: `grep -n 'sleep' htotheizzo.sh` shows `sleep 240` inside the keepalive loop and no other `sleep 50` remains there
+  - Manually unit-test the upgrade detection by temporarily setting `sw_list` to a value containing `"Version: 26"` (simulated future major) while on macOS 15 and running the detection block in isolation — confirm the warning is emitted containing both "interactive password" and "skip_softwareupdate_major=1"
+  - Manually test with `sw_list` containing only `"Version: 15"` — confirm no warning is emitted
+  - Manually test with `skip_softwareupdate_major=1` set and a major-upgrade `sw_list` — confirm no warning is emitted and the `--recommended` branch is taken
+  - Run `bash -n htotheizzo.sh` — script passes syntax check with zero errors
+  - _Requirements: 1.1, 1.2, 1.3, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6_

--- a/htotheizzo.sh
+++ b/htotheizzo.sh
@@ -70,7 +70,7 @@ progress() {
 
 # Keep sudo credentials alive in background for the duration of the script
 keep_sudo_alive() {
-  ( while kill -0 $$ 2>/dev/null; do sudo -v 2>/dev/null; sleep 50; done ) &
+  ( while kill -0 $$ 2>/dev/null; do sudo -v 2>/dev/null; sleep 240; done ) &
   local keepalive_pid=$!
   disown "$keepalive_pid" 2>/dev/null || true
   trap "kill $keepalive_pid 2>/dev/null || true" EXIT INT TERM
@@ -997,6 +997,28 @@ update() {
       while IFS= read -r line; do log "$line"; done <<< "$sw_list"
       progress "Installing macOS software updates"
       log "Installing Apple Software Updates"
+      # Warn before installing a major OS upgrade: it requires interactive auth even as root.
+      if [[ -z "${skip_softwareupdate_major:-}" ]]; then
+        local current_major
+        current_major=$(sw_vers -productVersion 2>/dev/null | cut -d. -f1 || true)
+        if [[ -n "$current_major" ]]; then
+          local found_major_upgrade=0
+          while IFS= read -r ver_line; do
+            local update_major
+            update_major=$(echo "$ver_line" | grep -oE '[0-9]+' | head -1 || true)
+            if [[ -n "$update_major" && "$update_major" -gt "$current_major" ]] 2>/dev/null; then
+              found_major_upgrade=1
+              break
+            fi
+          done < <(echo "$sw_list" | grep -oE 'Version: [0-9]+' || true)
+          if [[ "$found_major_upgrade" -eq 1 ]]; then
+            log "⚠ WARNING: A major macOS upgrade is available in the update list."
+            log "⚠ Major OS upgrades require an interactive password that bypasses sudo credential caching."
+            log "⚠ You will be prompted for your password even though sudo is already authenticated."
+            log "⚠ To skip major upgrades and install only recommended updates, set: skip_softwareupdate_major=1"
+          fi
+        fi
+      fi
       # --recommended installs security patches and minor updates headlessly.
       # Major OS upgrades (e.g. macOS Tahoe) require interactive auth even as root;
       # skip them here with skip_softwareupdate_major=1 or upgrade manually.


### PR DESCRIPTION
Add specification for reducing Touch ID prompts and warning about major OS upgrades in htotheizzo.sh script